### PR TITLE
fix: fix NUStudy quit command

### DIFF
--- a/src/main/java/arpa/home/nustudy/App.java
+++ b/src/main/java/arpa/home/nustudy/App.java
@@ -19,9 +19,9 @@ public class App {
         final String logo = "NUStudy\n";
         System.out.println("Hello from\n" + logo);
 
-        final boolean isExit = false;
+        boolean isExit = false;
 
-        while (!isExit) {
+        do {
             final String userInput = UserInterface.readInput();
 
             if (userInput == null) {
@@ -35,9 +35,13 @@ public class App {
             try {
                 final Command c = Parser.parseCommand(userInput);
                 c.execute(courseManager, sessionManager);
+
+                if (c.isExit()) {
+                    isExit = true;
+                }
             } catch (final NUStudyException e) {
                 System.out.println(e.getMessage());
             }
-        }
+        } while (!isExit);
     }
 }


### PR DESCRIPTION
The `quit` command did not work originally, because the associated logic was accidentally deleted in 09ff5afb2f6edb329ed1359ea4c26b0fedfd6e67. This pull request resolves the issue by restoring the quit logic.

Closes #43.