### PR TITLE
fix: command error help text

### DIFF
--- a/src/main/java/arpa/home/nustudy/utils/Parser.java
+++ b/src/main/java/arpa/home/nustudy/utils/Parser.java
@@ -59,8 +59,9 @@ public enum Parser {
      */
     private static Command parseAddCommand(final String arguments) throws NUStudyCommandException {
         if (arguments.isEmpty()) {
-            throw new NUStudyCommandException(
-                    "Add command requires arguments. Usage: add <course> OR add <course> <hours>");
+            throw new NUStudyCommandException("""
+                    Add command requires arguments.
+                    Usage: add <course> OR add <course> <hours>""");
         }
 
         final String[] parts = arguments.split("\\s+");
@@ -70,8 +71,9 @@ public enum Parser {
         } else if (parts.length >= 2) {  // If there are two or more words, treat as course + session
             return new AddSessionCommand(arguments);
         } else {
-            throw new NUStudyCommandException(
-                    "Invalid add command format. Usage: add <course> OR add <course> <hours>");
+            throw new NUStudyCommandException("""
+                    Invalid add command format.
+                    Usage: add <course> OR add <course> <hours>""");
         }
     }
 


### PR DESCRIPTION
Update the `list` command error text, referring to itself as `list` instead of `load` due to typo mistake.

Update the error text caused from invalid arguments to commands to be multi-line to improve clarity.

Closes #46.