### PR TITLE
docs(user-guide): fix GitHub Pages not rendering note alert

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -59,7 +59,8 @@ Add a course study session to the course book.
 
 Format: `add <course code> <study duration in hours> [date]`
 
-> [!NOTE]
+> **Note:**
+>
 > If `date` is not provided, today's date will be used.
 
 See [Appendix: Supported date formats](#appendix-supported-date-formats) for valid date formats.


### PR DESCRIPTION
Fix rendering of GitHub Pages not rendering GitHub Flavoured Markdown (GFM) alerts, replacing the note alert block with a regular block instead.

[Alert blocks](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/) are a feature of GitHub Flavoured Markdown (GFM), which renders correctly in GitHub README views, but does not render correctly in the [GitHub Pages website for the user guide](https://ay2526s1-cs2113-w14-2.github.io/tp/UserGuide.html#add-a-study-session-with-hours).

This may be due to GitHub Pages not supporting GFM, and just regular Markdown instead.

Closes #110.