### PR TITLE
fix: Add `add <course> <hours> <date>` to `add` command usage hints

### DIFF
--- a/src/main/java/arpa/home/nustudy/utils/CommandParser.java
+++ b/src/main/java/arpa/home/nustudy/utils/CommandParser.java
@@ -81,7 +81,7 @@ public class CommandParser {
         if (arguments.isEmpty()) {
             throw new NUStudyCommandException("""
                     Add command requires arguments.
-                    Usage: add <course> OR add <course> <hours>""");
+                    Usage: add <course> OR add <course> <hours> OR add <course> <hours> <date>""");
         }
 
         final String[] parts = arguments.split("\\s+");
@@ -94,7 +94,7 @@ public class CommandParser {
         } else {
             throw new NUStudyCommandException("""
                     Invalid add command format.
-                    Usage: add <course> OR add <course> <hours>""");
+                    Usage: add <course> OR add <course> <hours> OR add <course> <hours> <date>""");
         }
     }
 


### PR DESCRIPTION
Add `add <course> <hours> <date>` as a valid option to the `add` command usage hints, shown when the user inputs an invalid `add` command.

Fixes #164.