### PR TITLE
fix: Update logger to not print to console

### DIFF
--- a/src/main/java/arpa/home/nustudy/command/AddSessionCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/AddSessionCommand.java
@@ -16,9 +16,10 @@ import arpa.home.nustudy.session.SessionManager;
 import arpa.home.nustudy.ui.UserInterface;
 import arpa.home.nustudy.utils.DateParser;
 import arpa.home.nustudy.utils.HourValidator;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 public class AddSessionCommand implements Command {
-    private static final Logger logger = Logger.getLogger(AddSessionCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(AddSessionCommand.class);
     private final String input;
 
     /**

--- a/src/main/java/arpa/home/nustudy/command/DeleteCourseCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/DeleteCourseCommand.java
@@ -10,6 +10,7 @@ import arpa.home.nustudy.exceptions.NUStudyNoSuchCourseException;
 import arpa.home.nustudy.session.SessionManager;
 import arpa.home.nustudy.ui.UserInterface;
 import arpa.home.nustudy.utils.ConfirmationHandler;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 //@@author t-kandasami
 
@@ -18,7 +19,7 @@ import arpa.home.nustudy.utils.ConfirmationHandler;
  * course. Provides feedback through the UserInterface and logs actions.
  */
 public class DeleteCourseCommand implements Command {
-    private static final Logger logger = Logger.getLogger(DeleteCourseCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(DeleteCourseCommand.class);
     private final String input;
 
     /**

--- a/src/main/java/arpa/home/nustudy/command/EditCourseNameCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/EditCourseNameCommand.java
@@ -11,12 +11,13 @@ import arpa.home.nustudy.exceptions.NUStudyException;
 import arpa.home.nustudy.exceptions.NUStudyNoSuchCourseException;
 import arpa.home.nustudy.session.SessionManager;
 import arpa.home.nustudy.ui.UserInterface;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 /**
  * Edits (renames) an existing course. Command format: edit oldCourseName newCourseName
  */
 public class EditCourseNameCommand implements Command {
-    private static final Logger logger = Logger.getLogger(EditCourseNameCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(EditCourseNameCommand.class);
 
     private static final Pattern PATTERN = Pattern.compile("\\s+");
     private String oldCourseName;

--- a/src/main/java/arpa/home/nustudy/command/EditSessionCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/EditSessionCommand.java
@@ -17,9 +17,10 @@ import arpa.home.nustudy.session.Session;
 import arpa.home.nustudy.session.SessionManager;
 import arpa.home.nustudy.ui.UserInterface;
 import arpa.home.nustudy.utils.DateParser;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 public class EditSessionCommand implements Command {
-    private final Logger logger = Logger.getLogger(EditSessionCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(EditSessionCommand.class);
     private String input;
 
     public EditSessionCommand(final String input) {

--- a/src/main/java/arpa/home/nustudy/command/ExitCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/ExitCommand.java
@@ -3,6 +3,7 @@ package arpa.home.nustudy.command;
 import arpa.home.nustudy.course.CourseManager;
 import arpa.home.nustudy.exceptions.NUStudyException;
 import arpa.home.nustudy.session.SessionManager;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
@@ -10,7 +11,7 @@ import java.util.logging.Logger;
 
 //@@author Wrooi
 public class ExitCommand implements Command {
-    private static final Logger logger = Logger.getLogger(ExitCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(ExitCommand.class);
 
     static {
         logger.setLevel(Level.INFO);

--- a/src/main/java/arpa/home/nustudy/command/FilterByDateCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/FilterByDateCommand.java
@@ -13,6 +13,7 @@ import arpa.home.nustudy.utils.DateParser;
 import arpa.home.nustudy.exceptions.NUStudyCommandException;
 import arpa.home.nustudy.exceptions.WrongDateFormatException;
 import arpa.home.nustudy.exceptions.NUStudyException;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 /**
  * Command to filter and display courses that have sessions on a specified date.
@@ -22,7 +23,7 @@ import arpa.home.nustudy.exceptions.NUStudyException;
  * their original indices in the course list.
  */
 public class FilterByDateCommand implements Command {
-    private static final Logger logger = Logger.getLogger(FilterByDateCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(FilterByDateCommand.class);
 
     private final String dateString;
     private final Iterable<?> sessionSource; // optional test injection; if null, use the provided SessionManager

--- a/src/main/java/arpa/home/nustudy/command/FilterByNameAndDateCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/FilterByNameAndDateCommand.java
@@ -14,12 +14,13 @@ import arpa.home.nustudy.utils.DateParser;
 import arpa.home.nustudy.exceptions.WrongDateFormatException;
 import arpa.home.nustudy.exceptions.NUStudyCommandException;
 import arpa.home.nustudy.exceptions.NUStudyException;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 /**
  * Command to filter study sessions by exact course name (case-insensitive) and date.
  */
 public class FilterByNameAndDateCommand implements Command {
-    private static final Logger logger = Logger.getLogger(FilterByNameAndDateCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(FilterByNameAndDateCommand.class);
 
     private final String courseKeyword;
     private final String dateString;

--- a/src/main/java/arpa/home/nustudy/command/FilterByNameCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/FilterByNameCommand.java
@@ -9,6 +9,7 @@ import arpa.home.nustudy.exceptions.NUStudyCommandException;
 import arpa.home.nustudy.exceptions.NUStudyException;
 import arpa.home.nustudy.session.SessionManager;
 import arpa.home.nustudy.ui.UserInterface;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 /**
  * Command to filter courses by a keyword in their name or string representation.
@@ -21,7 +22,7 @@ import arpa.home.nustudy.ui.UserInterface;
  * {@link arpa.home.nustudy.ui.UserInterface#printFilteredCourseList(ArrayList, ArrayList, String)}.
  */
 public class FilterByNameCommand implements Command {
-    private static final Logger logger = Logger.getLogger(FilterByNameCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(FilterByNameCommand.class);
     private final String keyword;
 
     /**

--- a/src/main/java/arpa/home/nustudy/command/HelpCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/HelpCommand.java
@@ -5,12 +5,13 @@ import java.util.logging.Logger;
 
 import arpa.home.nustudy.course.CourseManager;
 import arpa.home.nustudy.session.SessionManager;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 /**
  * Displays a detailed help message for all available commands in NUStudy.
  */
 public class HelpCommand implements Command {
-    private static final Logger logger = Logger.getLogger(HelpCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(HelpCommand.class);
 
     public HelpCommand() {
     }

--- a/src/main/java/arpa/home/nustudy/command/ListCourseCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/ListCourseCommand.java
@@ -4,6 +4,7 @@ import arpa.home.nustudy.course.CourseManager;
 import arpa.home.nustudy.exceptions.NUStudyException;
 import arpa.home.nustudy.session.SessionManager;
 import arpa.home.nustudy.ui.UserInterface;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
@@ -12,7 +13,7 @@ import java.util.logging.Logger;
 //@@author Wrooi
 public class ListCourseCommand implements Command {
     // Add a logger for this command
-    private static final Logger logger = Logger.getLogger(ListCourseCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(ListCourseCommand.class);
 
     // Configure a lightweight console handler for this logger so logs are visible in tests/runs
     static {

--- a/src/main/java/arpa/home/nustudy/command/ResetCourseHoursCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/ResetCourseHoursCommand.java
@@ -9,13 +9,14 @@ import arpa.home.nustudy.exceptions.NUStudyException;
 import arpa.home.nustudy.exceptions.NUStudyNoSuchCourseException;
 import arpa.home.nustudy.session.SessionManager;
 import arpa.home.nustudy.utils.ConfirmationHandler;
+import arpa.home.nustudy.utils.LoggerHandler;
 
 /**
  * Creates a new ResetCourseHoursCommand with the specified user input. A specific course or all courses can be reset
  * depending on the input.
  */
 public class ResetCourseHoursCommand implements Command {
-    private static final Logger logger = Logger.getLogger(ResetCourseHoursCommand.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(ResetCourseHoursCommand.class);
     private final String input;
 
     /**

--- a/src/main/java/arpa/home/nustudy/utils/ConfirmationHandler.java
+++ b/src/main/java/arpa/home/nustudy/utils/ConfirmationHandler.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 import arpa.home.nustudy.ui.UserInterface;
 
 public class ConfirmationHandler {
-    private static final Logger logger = Logger.getLogger(ConfirmationHandler.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(ConfirmationHandler.class);
 
     /**
      * Handles user first confirmation prompts by persistently asking for a single 'y' or 'n' input. Handles lower (y/n)

--- a/src/main/java/arpa/home/nustudy/utils/LoggerHandler.java
+++ b/src/main/java/arpa/home/nustudy/utils/LoggerHandler.java
@@ -1,0 +1,41 @@
+package arpa.home.nustudy.utils;
+
+import java.io.UnsupportedEncodingException;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+public class LoggerHandler {
+    private static final Logger LOGGER = Logger.getLogger("NUStudy");
+    private static final LogManager LOG_MANAGER = LogManager.getLogManager();
+    private static final ConsoleHandler CONSOLE_HANDLER = new ConsoleHandler();
+
+    static {
+        LOG_MANAGER.addLogger(LOGGER);
+
+        CONSOLE_HANDLER.setLevel(Level.OFF);
+
+        try {
+            CONSOLE_HANDLER.setEncoding("UTF-8");
+        } catch (final UnsupportedEncodingException ignored) {
+            // Ignore since UTF-8 is a valid encoding
+        }
+
+        LOGGER.setLevel(Level.OFF);
+        LOGGER.addHandler(CONSOLE_HANDLER);
+        LOGGER.setUseParentHandlers(false);
+    }
+
+    public static <T> Logger getLogger(final Class<T> logClass) {
+        final Logger newLogger = Logger.getLogger(logClass.getName());
+
+        LOG_MANAGER.addLogger(newLogger);
+
+        newLogger.setLevel(Level.OFF);
+        newLogger.addHandler(CONSOLE_HANDLER);
+        newLogger.setUseParentHandlers(false);
+
+        return newLogger;
+    }
+}

--- a/src/main/java/arpa/home/nustudy/utils/Storage.java
+++ b/src/main/java/arpa/home/nustudy/utils/Storage.java
@@ -19,7 +19,7 @@ import arpa.home.nustudy.session.SessionManager;
  * Handles loading and saving tasks to a data file.
  */
 public class Storage {
-    private static final Logger logger = Logger.getLogger(Storage.class.getName());
+    private static final Logger logger = LoggerHandler.getLogger(Storage.class);
     private final File dataFile;
 
     /**


### PR DESCRIPTION
Add `LoggerHandler` helper class to not print logs to console, irrespective of logging level.

Fixes #152.

Fixes #156.