### PR TITLE
docs: Update user guide links and text

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -11,7 +11,8 @@ type fast, NUStudy can get your study management tasks done faster than traditio
 - [**Features**](#features)
     - [Help](#help)
     - [Add a course](#add-a-course)
-    - [Add a study session with hours](#add-a-study-session-with-hours)
+    - [Add a study session for today](#add-a-study-session-for-today)
+    - [Add a study session with custom date](#add-a-study-session-with-custom-date)
     - [List all added courses](#list-all-added-courses)
     - [List study sessions for a course](#list-study-sessions-for-a-course)
     - [Edit a course code](#edit-a-course-code)
@@ -56,7 +57,7 @@ Expected output:
     ---------------------------------------------------------------------------------------------------
     Help                               help                                help
     Add a course                       add <course code>                   add CS2113
-    Add a study session                add <course code> <hours>           add CS2113 5
+    Add a study session for today      add <course code> <hours>           add CS2113 5
     Add a study session with date      add <course code> <hours> <date>    add CS2113 5 23/10/2025
     List all courses                   list                                list
     List study sessions                list <course code>                  list CS2113
@@ -88,14 +89,13 @@ Expected output:
 Good Job! You have added CS2113
 ```
 
-### Add a study session without date
+### Add a study session for today
 
-Add a course study session to the course book.
+Add a course study session to the course book with today's date.
 
 Format: `add <course code> <study duration in hours>`
 
 > **Note:**
->
 >
 > Today's date will be used.
 >
@@ -111,14 +111,13 @@ Expected output:
 Good Job! You have studied 5.0 hours for CS2113
 ```
 
-### Add a study session with date
+### Add a study session with custom date
 
-Add a course study session to the course book.
+Add a course study session to the course book with custom date.
 
 Format: `add <course code> <study duration in hours> <date>`
 
 > **Note:**
->
 >
 > Future dates are not allowed. Any date strictly after today's date will be rejected with an informative error; provide
 > a past or today's date.
@@ -423,7 +422,8 @@ Input character rules:
 |--------|---------------------------------------------------------------------------------|--------------------------------------------------------------------|----------------------------|
 | Help   | [Help](#help)                                                                   | `help`                                                             | `help`                     |
 | Add    | [Add a course](#add-a-course)                                                   | `add <course code>`                                                | `add CS2113`               |
-|        | [Add a study session with hours](#add-a-study-session-with-hours)               | `add <course code> <study duration in hours> [date]`               | `add CS2113 5`             |
+|        | [Add a study session for today](#add-a-study-session-for-today)                 | `add <course code> <study duration in hours>`                      | `add CS2113 5`             |
+|        | [Add a study session with custom date](#add-a-study-session-with-custom-date)   | `add <course code> <study duration in hours> <date>`               | `add CS2113 5 04/11/2025`  |
 | List   | [List all added courses](#list-all-added-courses)                               | `list`                                                             | `list`                     |
 |        | [List study sessions for a course](#list-study-sessions-for-a-course)           | `list <course code>`                                               | `list CS2113`              |
 | Edit   | [Edit a course code](#edit-a-course-code)                                       | `edit <old course code> <new course code>`                         | `edit CS2113 MA1511`       |
@@ -449,4 +449,4 @@ rejected):
 
 ## Appendix: Supported hour range
 
-NUStudy supports hours starting from 0.5 to 24 with 0.5 increment only.
+NUStudy supports hours starting from 0.5 to 24, with 0.5 increment only.

--- a/src/main/java/arpa/home/nustudy/command/HelpCommand.java
+++ b/src/main/java/arpa/home/nustudy/command/HelpCommand.java
@@ -27,7 +27,7 @@ public class HelpCommand implements Command {
                  ---------------------------------------------------------------------------------------------------
                  Help                               help                                help
                  Add a course                       add <course code>                   add CS2113
-                 Add a study session                add <course code> <hours>           add CS2113 5
+                 Add a study session for today      add <course code> <hours>           add CS2113 5
                  Add a study session with date      add <course code> <hours> <date>    add CS2113 5 23/10/2025
                  List all courses                   list                                list
                  List study sessions                list <course code>                  list CS2113


### PR DESCRIPTION
Update user guide to fix links in table of contents and command guide, as per #200.

Update `help` command to specify adding course without date assumes today's date.

Update whitespace formatting of user guide.

Closes #200.