### PR TITLE
docs: Clarify input caret in user guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -300,7 +300,7 @@ Format: `reset <course>`, or `reset all`
 
 Example: `reset CS2113`
 
-Expected output (_`>` indicates user input_):
+Expected output (_`>` indicates user input, but is not shown in the program_):
 
 ```
 Are you sure of resetting hours for CS2113 (y/n)?
@@ -313,7 +313,7 @@ Logged hours for CS2113 have been reset
 
 Example: `reset all`
 
-Expected output (_`>` indicates user input_):
+Expected output (_`>` indicates user input, but is not shown in the program_):
 
 ```
 Are you sure you want to reset hours for ALL courses? (y/n)
@@ -332,7 +332,7 @@ Format: `delete <course code>`
 
 Example: `delete CS2113`
 
-Expected output (_`>` indicates user input_):
+Expected output (_`>` indicates user input, but is not shown in the program_):
 
 ```
 Are you sure you want to delete CS2113 (y/n)?


### PR DESCRIPTION
Update user guide to clarify the seemingly missing caret while the program waits for confirmation.

Fixes #205.